### PR TITLE
Add OffscreenCanvas to transferables

### DIFF
--- a/greenlet.js
+++ b/greenlet.js
@@ -23,7 +23,8 @@ export default function greenlet(asyncFunction) {
 				postMessage([e.data[0], 0, d], [d].filter(x => (
 					(x instanceof ArrayBuffer) ||
 					(x instanceof MessagePort) ||
-					(self.ImageBitmap && x instanceof ImageBitmap)
+					(self.ImageBitmap && x instanceof ImageBitmap) ||
+					(self.OffscreenCanvas && x instanceof OffscreenCanvas)
 				)));
 			},
 			// error handler - callback(id, ERROR(1), error)
@@ -60,7 +61,8 @@ export default function greenlet(asyncFunction) {
 			worker.postMessage([currentId, args], args.filter(x => (
 				(x instanceof ArrayBuffer) ||
 				(x instanceof MessagePort) ||
-				(self.ImageBitmap && x instanceof ImageBitmap)
+				(self.ImageBitmap && x instanceof ImageBitmap) ||
+				(self.OffscreenCanvas && x instanceof OffscreenCanvas)
 			)));
 		});
 	};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "source": "greenlet.js",
   "main": "dist/greenlet.js",
   "module": "dist/greenlet.m.js",
+  "exports": "dist/greenlet.modern.js",
+  "unpkg": "dist/greenlet.umd.js",
   "types": "./index.d.ts",
   "scripts": {
     "prepare": "microbundle",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "license": "MIT",
   "homepage": "https://github.com/developit/greenlet",
   "devDependencies": {
-    "eslint": "^4.16.0",
-    "eslint-config-developit": "^1.1.1",
+    "eslint": "^7.21.0",
+    "eslint-config-developit": "^1.2.0",
     "karmatic": "^1.4.0",
     "microbundle": "^0.4.3",
     "webpack": "^4.29.6"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^7.21.0",
     "eslint-config-developit": "^1.2.0",
     "karmatic": "^1.4.0",
-    "microbundle": "^0.4.3",
+    "microbundle": "^0.13.0",
     "webpack": "^4.29.6"
   }
 }


### PR DESCRIPTION
This PR:
- adds support for [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) as part of Greenlet's transferables list.
- upgrades ESLint to comply with the latest version of [eslint-config-developit](https://github.com/developit/eslint-config-developit).
- upgrades to the latest Microbundle version.
- specifies additional exports provided by Microbundle (UMD and [Modern ✨](https://github.com/developit/microbundle#modern)).